### PR TITLE
Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add rules below in rules section.
 
 # List of supported rules
 
-* reselect/first-param-name: First param must be named `state`. Name can be configured. Here is an example with `fullState`: 
+* reselect/first-param-name: First param must be named `state`. Name can be configured. Here is an example with `fullState`:
 ```js
 "rules": {
 	...
@@ -46,22 +46,22 @@ Add rules below in rules section.
     "reselect/maximum-arity": ["error", 3],
     ...
 ```
-* reselect/second-param-destructured: Second argument must be a destructuring object. 
+* reselect/second-param-destructured: Second argument must be a destructuring object.
 * reselect/call: When calling a selector function, second argument must be an object declaration. Selector call is identified like this:
-  * Called function  begins with `get`
+  * Called function  begins with `get`, unless otherwise configured in eslint settings
   * Function called with 2 parameters
-  * First parameter must be `state`
-* reselect/prefer-create-selector: Instead of use selector in selector, prefer use of createSelector function. 
+  * First parameter must be `state`, unless otherwise configured in eslint settings
+* reselect/prefer-create-selector: Instead of use selector in selector, prefer use of createSelector function.
 
 All rules except `reselect/call` are triggered when :
  * `reselect` is imported
- * function name begins with `get`
+ * function name begins with `get`, or is otherwise configured in eslint settings
  * function at root level (exported or not)
  * functions in createSelector calls (not the latest)
 
 If you don't use [Reselect](https://github.com/reactjs/reselect) in your selector file, you can just import [Reselect](https://github.com/reactjs/reselect) like this to enable rules
 
-```js 
+```js
 import 'reselect';
 ```
 

--- a/lib/rules/call.js
+++ b/lib/rules/call.js
@@ -1,15 +1,18 @@
-function test(context, node) {
-  if (node.arguments[1].type !== 'ObjectExpression') {
-    context.report(node.arguments[1], 'Second argument must be an object declaration');
-  }
-}
+const utils = require('../utils');
 
 module.exports = (context) => {
-  const startWith = context.options[0] || 'get';
-  const paramName = context.options[1] || 'state';
+  const selectorMethodPrefix = utils.getSelectorMethodPrefix(context, context.options[0]);
+
+  const paramName = utils.getStateParamName(context, context.options[1]);
+
+  function test(node) {
+    if (node.arguments[1].type !== 'ObjectExpression') {
+      context.report(node.arguments[1], 'Second argument must be an object declaration');
+    }
+  }
 
   return {
-    [`CallExpression[callee.name=/^${startWith}.+/][arguments.length=2][arguments.0.name=${paramName}]`]: test.bind(null, context),
+    [`CallExpression[callee.name=/^${selectorMethodPrefix}.+/][arguments.length=2][arguments.0.name=${paramName}]`]: test,
   };
 };
 

--- a/lib/rules/first-param-name.js
+++ b/lib/rules/first-param-name.js
@@ -3,20 +3,19 @@ const utils = require('../utils');
 const isReselectImported = utils.isReselectImported;
 const getSelectors = utils.getSelectors;
 
-function test(context, node) {
-  const paramName = context.options[0] || 'state';
-  if (!isReselectImported(context)) {
-    return;
-  }
-
-  context.report(node, `First parameter must be named '${paramName}'`);
-}
-
 module.exports = (context) => {
-  const paramName = context.options[0] || 'state';
+  const paramName = utils.getStateParamName(context, context.options[0]);
   const condition = ` .params:first-child[name!=${paramName}]`;
 
-  return getSelectors(condition, test.bind(null, context));
+  function test(node) {
+    if (!isReselectImported(context)) {
+      return;
+    }
+
+    context.report(node, `First parameter must be named '${paramName}'`);
+  }
+
+  return getSelectors(condition, test, context);
 };
 
 module.schema = [

--- a/lib/rules/maximum-arity.js
+++ b/lib/rules/maximum-arity.js
@@ -3,20 +3,19 @@ const utils = require('../utils');
 const isReselectImported = utils.isReselectImported;
 const getSelectors = utils.getSelectors;
 
-function test(context, node) {
-  const arity = context.options[0] || 2;
-  if (!isReselectImported(context)) {
-    return;
-  }
-
-  context.report(node, `Maximum arity in selector must be ${arity}`);
-}
-
 module.exports = (context) => {
   const arity = context.options[0] || 2;
   const condition = `[params.length>${arity}]`;
 
-  return getSelectors(condition, test.bind(null, context));
+  function test(node) {
+    if (!isReselectImported(context)) {
+      return;
+    }
+
+    context.report(node, `Maximum arity in selector must be ${arity}`);
+  }
+
+  return getSelectors(condition, test, context);
 };
 
 module.schema = [
@@ -24,4 +23,3 @@ module.schema = [
     type: 'integer',
   },
 ];
-

--- a/lib/rules/prefer-create-selector.js
+++ b/lib/rules/prefer-create-selector.js
@@ -3,18 +3,20 @@ const utils = require('../utils');
 const isReselectImported = utils.isReselectImported;
 const getSelectors = utils.getSelectors;
 
-function test(context, node) {
-  if (!isReselectImported(context)) {
-    return;
+module.exports = (context) => {
+  const selectorMethodPrefix = utils.getSelectorMethodPrefix(context);
+
+  const condition = ` :matches(CallExpression[callee.name=/^${selectorMethodPrefix}.+/][parent.type=/Function/], :not(Property) > CallExpression[callee.name=/^${selectorMethodPrefix}.+/][arguments.length=1][arguments.0.name=/state/])`;
+
+  function test(node) {
+    if (!isReselectImported(context)) {
+      return;
+    }
+
+    context.report(node, 'Prefer use of createSelector function');
   }
 
-  context.report(node, 'Prefer use of createSelector function');
-}
-
-module.exports = (context) => {
-  const condition = ' :matches(CallExpression[callee.name=/^get.+/][parent.type=/Function/], :not(Property) > CallExpression[callee.name=/^get.+/][arguments.length=1][arguments.0.name=/state/])';
-
-  return getSelectors(condition, test.bind(null, context));
+  return getSelectors(condition, test, context);
 };
 
 module.schema = [

--- a/lib/rules/second-param-destructured.js
+++ b/lib/rules/second-param-destructured.js
@@ -3,20 +3,20 @@ const utils = require('../utils');
 const isReselectImported = utils.isReselectImported;
 const getSelectors = utils.getSelectors;
 
-function test(context, node) {
-  if (!isReselectImported(context)) {
-    return;
-  }
-
-  if (node.params[1].type !== 'ObjectPattern') {
-    context.report(node.params[1], 'Second argument must be destructured');
-  }
-}
-
 module.exports = (context) => {
   const condition = '[params.length=2]';
 
-  return getSelectors(condition, test.bind(null, context));
-};
-module.schema = [];
+  function test(node) {
+    if (!isReselectImported(context)) {
+      return;
+    }
 
+    if (node.params[1].type !== 'ObjectPattern') {
+      context.report(node.params[1], 'Second argument must be destructured');
+    }
+  }
+
+  return getSelectors(condition, test, context);
+};
+
+module.schema = [];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,26 @@
+function escapeRegExp(str) {
+  return str && str.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+}
+
+function getStateParamName(context, override) {
+  const settings = context.settings || {};
+
+  return (
+    override ||
+    escapeRegExp(settings['reselect/stateParamName']) ||
+    'state'
+  );
+}
+
+function getSelectorMethodPrefix(context, override) {
+  const settings = context.settings || {};
+  return (
+    override ||
+    escapeRegExp(settings['reselect/selectorMethodPrefix']) ||
+    'get'
+  );
+}
+
 const isReselectImported = (context) => {
   const imports = context.getSourceCode().ast.body
     .filter(n => n.type === 'ImportDeclaration');
@@ -5,7 +28,9 @@ const isReselectImported = (context) => {
   return imports.some(n => n.source.value === 'reselect');
 };
 
-const getSelectors = (condition, test, options) => {
+const getSelectors = (condition, test, context, options) => {
+  const selectorMethodPrefix = getSelectorMethodPrefix(context);
+
   const opt = Object.assign(
     {
       createSelectorPattern: '^create.*Selector',
@@ -13,20 +38,27 @@ const getSelectors = (condition, test, options) => {
     options // eslint-disable-line comma-dangle
   );
 
-  return {
-    [`:matches(Program, Program > ExportNamedDeclaration) > :function[id.name=/^get/]${condition}`]:
-      test,
-    [`:matches(Program, Program > ExportNamedDeclaration) > :declaration > [id.name=/^get/] > :function${condition}`]:
-      test,
-    [`[key.name=/^get/] > :function${condition}`]:
-      test,
-    [`CallExpression[callee.name=/${opt.createSelectorPattern}/] > :function:not(:last-child)${condition}`]:
-      test,
-    [`ExportDefaultDeclaration :function[params.0.name=/state/]${condition}`]: test,
-  };
+  const paramName = getStateParamName(context);
+
+  const rules = [
+    `:matches(Program, Program > ExportNamedDeclaration) > :function[id.name=/^${selectorMethodPrefix}/]${condition}`,
+    `:matches(Program, Program > ExportNamedDeclaration) > :declaration > [id.name=/^${selectorMethodPrefix}/] > :function${condition}`,
+    `[key.name=/^${selectorMethodPrefix}/] > :function${condition}`,
+    `CallExpression[callee.name=/${opt.createSelectorPattern}/] > :function:not(:last-child)${condition}`,
+    `ExportDefaultDeclaration :function[params.0.name=/${paramName}/]${condition}`,
+  ];
+
+  return rules.reduce((acc, rule) => {
+    acc[rule] = test;
+
+    return acc;
+  }, {});
 };
 
 module.exports = {
+  escapeRegExp,
+  getStateParamName,
+  getSelectorMethodPrefix,
   isReselectImported,
   getSelectors,
 };

--- a/tests/lib/rules/call.js
+++ b/tests/lib/rules/call.js
@@ -41,6 +41,27 @@ ruleTester.run('call', rule, {
 'const foo = getFoo(state);',
         parserOptions,
       },
+      {
+        code:
+'const foo = selectFoo(state);',
+        settings: { 'reselect/selectorMethodPrefix': 'select' },
+        parserOptions,
+      },
+      {
+        code:
+'const foo = getFoo(appState);',
+        settings: { 'reselect/stateParamName': 'appState' },
+        parserOptions,
+      },
+      {
+        code:
+'const foo = selectFoo(appState);',
+        settings: {
+          'reselect/selectorMethodPrefix': 'select',
+          'reselect/stateParamName': 'appState',
+        },
+        parserOptions,
+      },
     ]),
   invalid: []
     .concat([
@@ -63,6 +84,45 @@ ruleTester.run('call', rule, {
           message: 'Second argument must be an object declaration',
           line: 1,
           column: 26,
+          type: 'Identifier',
+        }],
+        parserOptions,
+      },
+      {
+        code:
+'const foo = selectFoo(state, id);',
+        settings: { 'reselect/selectorMethodPrefix': 'select' },
+        errors: [{
+          message: 'Second argument must be an object declaration',
+          line: 1,
+          column: 30,
+          type: 'Identifier',
+        }],
+        parserOptions,
+      },
+      {
+        code:
+'const foo = getFoo(appState, id);',
+        settings: { 'reselect/stateParamName': 'appState' },
+        errors: [{
+          message: 'Second argument must be an object declaration',
+          line: 1,
+          column: 30,
+          type: 'Identifier',
+        }],
+        parserOptions,
+      },
+      {
+        code:
+'const foo = selectFoo(appState, id);',
+        settings: {
+          'reselect/selectorMethodPrefix': 'select',
+          'reselect/stateParamName': 'appState',
+        },
+        errors: [{
+          message: 'Second argument must be an object declaration',
+          line: 1,
+          column: 33,
           type: 'Identifier',
         }],
         parserOptions,

--- a/tests/lib/rules/first-param-name.js
+++ b/tests/lib/rules/first-param-name.js
@@ -39,6 +39,25 @@ const getView = (st, { id }) => state;`,
 'const getView = (one, two, three) => one;',
         parserOptions,
       },
+      {
+        code:
+'const selectView = (one, two, three) => one;',
+        settings: { 'reselect/selectorMethodPrefix': 'select' },
+        parserOptions,
+      },
+      {
+        code:
+'const getView = (appState) => one;',
+        settings: { 'reselect/stateParamName': 'appState' },
+        parserOptions,
+      },
+      {
+        code:
+'const getView = (st) => one;',
+        options: ['st'],
+        settings: { 'reselect/stateParamName': 'appState' },
+        parserOptions,
+      },
     ]),
   invalid: []
     .concat([
@@ -120,6 +139,85 @@ const getFoo = createSelector(
             message: 'First parameter must be named \'st\'',
             line: 3,
             column: 4,
+            type: 'Identifier',
+          },
+        ],
+        parserOptions,
+      },
+      {
+        code:
+`import 'reselect';
+const selectView = (one, two, three) => one;`,
+        settings: { 'reselect/selectorMethodPrefix': 'select' },
+        errors: [
+          {
+            message: 'First parameter must be named \'state\'',
+            line: 2,
+            column: 21,
+            type: 'Identifier',
+          },
+        ],
+        parserOptions,
+      },
+      {
+        code:
+`import 'reselect';
+const selectView = (one, two, three) => one;`,
+        settings: { 'reselect/selectorMethodPrefix': 'select' },
+        errors: [
+          {
+            message: 'First parameter must be named \'state\'',
+            line: 2,
+            column: 21,
+            type: 'Identifier',
+          },
+        ],
+        parserOptions,
+      },
+      {
+        code:
+`import 'reselect';
+const getView = (state) => one;`,
+        settings: { 'reselect/stateParamName': 'appState' },
+        errors: [
+          {
+            message: 'First parameter must be named \'appState\'',
+            line: 2,
+            column: 18,
+            type: 'Identifier',
+          },
+        ],
+        parserOptions,
+      },
+      {
+        code:
+`import 'reselect';
+const selectView = (state) => one;`,
+        settings: {
+          'reselect/selectorMethodPrefix': 'select',
+          'reselect/stateParamName': 'appState',
+        },
+        errors: [
+          {
+            message: 'First parameter must be named \'appState\'',
+            line: 2,
+            column: 21,
+            type: 'Identifier',
+          },
+        ],
+        parserOptions,
+      },
+      {
+        code:
+`import 'reselect';
+const getView = (appState) => one;`,
+        options: ['st'],
+        settings: { 'reselect/stateParamName': 'appState' },
+        errors: [
+          {
+            message: 'First parameter must be named \'st\'',
+            line: 2,
+            column: 18,
             type: 'Identifier',
           },
         ],

--- a/tests/lib/rules/maximum-arity.js
+++ b/tests/lib/rules/maximum-arity.js
@@ -56,13 +56,26 @@ const getFoo = function(state, id, foo) { return true; }`,
       },
       {
         code:
-`import { createSelector } from 'reselect';
+`import 'reselect';
 export default (state, foo, bar) => state;`,
         errors: [{
           message: 'Maximum arity in selector must be 2',
           line: 2,
           column: 16,
           type: 'ArrowFunctionExpression',
+        }],
+        parserOptions,
+      },
+      {
+        code:
+`import 'reselect';
+const selectFoo = function(state, id, foo) { return true; }`,
+        settings: { 'reselect/selectorMethodPrefix': 'select' },
+        errors: [{
+          message: 'Maximum arity in selector must be 2',
+          line: 2,
+          column: 19,
+          type: 'FunctionExpression',
         }],
         parserOptions,
       },

--- a/tests/lib/rules/prefer-create-selector.js
+++ b/tests/lib/rules/prefer-create-selector.js
@@ -52,6 +52,16 @@ const getFoo = (state) => ({
 })`,
         parserOptions,
       },
+      {
+        code:
+`import 'reselect';
+const selectFoo = (state) => ({
+  a: selectA(state),
+  b: selectB(state)
+})`,
+        settings: { 'reselect/selectorMethodPrefix': 'select' },
+        parserOptions,
+      },
     ]),
   invalid: []
     .concat([
@@ -109,6 +119,21 @@ export const getTest = (state) => getFoo(state);`,
             message: 'Prefer use of createSelector function',
             line: 2,
             column: 35,
+            type: 'CallExpression',
+          },
+        ],
+        parserOptions,
+      },
+      {
+        code:
+`import { createSelector } from 'reselect';
+export const selectTest = (state) => selectFoo(state);`,
+        settings: { 'reselect/selectorMethodPrefix': 'select' },
+        errors: [
+          {
+            message: 'Prefer use of createSelector function',
+            line: 2,
+            column: 38,
             type: 'CallExpression',
           },
         ],

--- a/tests/lib/rules/second-param-destructured.js
+++ b/tests/lib/rules/second-param-destructured.js
@@ -17,7 +17,7 @@ const parserOptions = {
 // Tests
 // ------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester()
+const ruleTester = new RuleTester();
 ruleTester.run('second-param-destructured', rule, {
   valid: []
     .concat([
@@ -30,6 +30,12 @@ const getView = (state, { id }) => state;`,
       {
         code:
 'const getView = (one, two, three) => one;',
+        parserOptions,
+      },
+      {
+        code:
+'const selectView = (one, two, three) => one;',
+        settings: { 'reselect/selectorMethodPrefix': 'select' },
         parserOptions,
       },
     ]),
@@ -106,6 +112,19 @@ const getFoo = createSelector(
           },
         ],
         parserOptions,
-      }
+      },
+      {
+        code:
+`import { createSelector } from 'reselect';
+const selectFoo = function(state, id) { return true; }`,
+        settings: { 'reselect/selectorMethodPrefix': 'select' },
+        errors: [{
+          message: 'Second argument must be destructured',
+          line: 2,
+          column: 35,
+          type: 'Identifier',
+        }],
+        parserOptions,
+      },
     ]),
 });

--- a/tests/lib/rules/second-param-destructured.js
+++ b/tests/lib/rules/second-param-destructured.js
@@ -2,22 +2,22 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-var rule = require('../../../lib/rules/second-param-destructured')
-var RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/second-param-destructured');
+const RuleTester = require('eslint').RuleTester;
 
-var parserOptions = {
+const parserOptions = {
   ecmaVersion: 6,
-  sourceType: "module",
+  sourceType: 'module',
   ecmaFeatures: {
-    experimentalObjectRestSpread: true
-  }
-}
+    experimentalObjectRestSpread: true,
+  },
+};
 
 // ------------------------------------------------------------------------------
 // Tests
 // ------------------------------------------------------------------------------
 
-var ruleTester = new RuleTester()
+const ruleTester = new RuleTester()
 ruleTester.run('second-param-destructured', rule, {
   valid: []
     .concat([
@@ -25,12 +25,12 @@ ruleTester.run('second-param-destructured', rule, {
         code:
 `import { createSelector } from 'reselect';
 const getView = (state, { id }) => state;`,
-        parserOptions: parserOptions
+        parserOptions,
       },
       {
         code:
-`const getView = (one, two, three) => one;`,
-        parserOptions: parserOptions
+'const getView = (one, two, three) => one;',
+        parserOptions,
       },
     ]),
   invalid: []
@@ -43,9 +43,9 @@ const getFoo = function(state, id) { return true; }`,
           message: 'Second argument must be destructured',
           line: 2,
           column: 32,
-          type: 'Identifier'
+          type: 'Identifier',
         }],
-        parserOptions: parserOptions
+        parserOptions,
       },
       {
         code:
@@ -55,9 +55,9 @@ const getFoo = (state, id) => true`,
           message: 'Second argument must be destructured',
           line: 2,
           column: 24,
-          type: 'Identifier'
+          type: 'Identifier',
         }],
-        parserOptions: parserOptions
+        parserOptions,
       },
       {
         code:
@@ -67,9 +67,9 @@ export const getFoo = (state, id) => true`,
           message: 'Second argument must be destructured',
           line: 2,
           column: 31,
-          type: 'Identifier'
+          type: 'Identifier',
         }],
-        parserOptions: parserOptions
+        parserOptions,
       },
       {
         code:
@@ -79,9 +79,9 @@ export function getFoo(state, id) { return true }`,
           message: 'Second argument must be destructured',
           line: 2,
           column: 31,
-          type: 'Identifier'
+          type: 'Identifier',
         }],
-        parserOptions: parserOptions
+        parserOptions,
       },
       {
         code:
@@ -96,16 +96,16 @@ const getFoo = createSelector(
             message: 'Second argument must be destructured',
             line: 3,
             column: 11,
-            type: 'Identifier'
+            type: 'Identifier',
           },
           {
             message: 'Second argument must be destructured',
             line: 4,
             column: 11,
-            type: 'Identifier'
-          }
+            type: 'Identifier',
+          },
         ],
-        parserOptions: parserOptions
+        parserOptions,
       }
-    ])
-})
+    ]),
+});


### PR DESCRIPTION
eslint-plugin-reselect is opinionated in how selectors and state variables are named.

This PR adds the eslint-wide settings
`reselect/stateParamName` and `reselect/selectorMethodPrefix` to allow configuration of all rules' behavior in a single location.

eslint-wide settings are overridden by rule-specific configurations.
AST Node tests are no longer explicitly bound to `context`, but capture it within their closure scope.

The README is barely updated, but can be fleshed out with a small section on the usage of these settings.